### PR TITLE
posts_per_page filter at get-param, dom-default, & at runtime 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## Description
+> As a developer, I need to start with a story.
+
+_A few sentences describing the overall goals of the pull request's commits.
+What is the current behavior of the app? What is the updated/expected behavior
+with this PR? **Include your acceptance critiera!** If your tasks were well-written, you can probably copy/paste some of this._
+
+## Affected URL
+[link_to_relevant_multidev_or_test_site](insert_link_here)
+
+## Related Tickets
+
+* [insert_ticket_name_here](insert_link_here)
+
+## Steps to Validate
+1. A list of steps to validate
+1. Include direct links to test sites -- specific nodes, admin screens, etc
+1. Be explicit
+
+## Deploy Notes
+
+_Notes regarding deployment of the contained body of work. These should note any
+new dependencies, new scripts, etc._
+
+**New scripts**:
+
+- `script` : script details
+
+**New dependencies**:
+
+- `dependency` : dependency details
+
+**New dev dependencies**:
+
+- `dependency` : dependency details

--- a/includes/class-wp-ajax.php
+++ b/includes/class-wp-ajax.php
@@ -183,9 +183,6 @@ class Wp_Ajax {
 
 		$this->loader->add_action( 'pre_get_posts', $plugin_public, 'taxosearch_groupby' );
 
-		// todo: possibly remove
-		$this->loader->add_action( 'parse_query', $plugin_public, 'disable_canonical_redirect' );
-
 	}
 
 	/**

--- a/public/class-wp-ajax-public.php
+++ b/public/class-wp-ajax-public.php
@@ -184,11 +184,14 @@ class Wp_Ajax_Public {
 	 */
 	function ajax_shortcode( $props, $content = null ) {
 
-		$props = shortcode_atts( [ 'post_type' => false, 'taxo' => false, 'term' => false, ], $props, 'ajax' );
+		$props = shortcode_atts( [ 'post_type' => false, 'posts_per_page' => false, 'taxo' => false, 'term' => false, ], $props, 'ajax' );
 		$attrs = [ 'class' => 'wp-ajax-wrap' ];
 
 		if ( ! empty( $props['post_type'] ) ) :
 			$attrs[ 'post_type' ] = $props['post_type'];
+		endif;
+		if ( ! empty( $props['posts_per_page'] ) ) :
+			$attrs[ 'posts_per_page' ] = $props['posts_per_page'];
 		endif;
 		if ( ! empty( $props['taxo'] ) ) :
 			$attrs[ 'taxo' ] = $props['taxo'];
@@ -249,6 +252,8 @@ class Wp_Ajax_Public {
 
 		if ( 'post_type' === $props['query_var'] ) {
 			$query_var = 'ajax_post_type';
+		} elseif ( 'posts_per_page' === $props['query_var'] ) {
+			$query_var = 'ajax_posts_per_page';
 		} else {
 			$query_var = sanitize_key( $props['query_var'] );
 		}
@@ -343,13 +348,5 @@ class Wp_Ajax_Public {
 	public function taxosearch_posts_groupby( $groupby ) {
 		return '';
 	}
-
-	public function disable_canonical_redirect( $query ) {
-		if ( ! empty( $_GET['wpjx'] ) && 1 === intval( $_GET['wpjx'] ) ) {
-			remove_filter( 'template_redirect', 'redirect_canonical' );
-		}
-	}
-
-
 
 }

--- a/public/js/wp-ajax-public.js
+++ b/public/js/wp-ajax-public.js
@@ -484,14 +484,15 @@
 
 		/*
 		* Build URL Object
+		* Returns dest: current url-base, sub_params_out: json-object with get-params as names & arrays built from csv-string
 		**/
 		buildUrlObject : function(){
 
-		    dest = window.location.origin,
+		    dest = window.location.origin + window.location.pathname,
 		    params = window.location.search.replace( '?', '' ),
 		    sub_params_out = {};
 
-		    dest += window.location.pathname;
+
 
 		    if ( params.length ) {
 		        var sub_params = params.split( '&' );
@@ -500,6 +501,7 @@
 		    if ( sub_params ) {
 		        for ( var i in sub_params ) {
 		            var item = sub_params[ i ].split( '=' );
+					
 		            sub_params_out[ item[ 0 ] ] = item[ 1 ].split( ',' );
 		        }
 		    }
@@ -510,6 +512,8 @@
 
 		/*
 		* Add URL Param
+		* Adds new item onto array-type wp-query property.
+		* This function receives a key-value pair from element-attributes, creates the key on a destination url-string if does not exist & adds value
 		**/
 		addUrlParam : function( e ) {
 
@@ -525,7 +529,6 @@
 			if ( urlObj.sub_params_out.hasOwnProperty( queryvar ) ) {
 				if ( urlObj.sub_params_out[ queryvar ].indexOf( queryval ) === - 1 ) {
 					urlObj.sub_params_out[ queryvar ].push( queryval );
-					// urlObj = buildUrlObject();
 				} else {
 					removeUrlParam( e );
 					return false;
@@ -546,6 +549,8 @@
 
 		/*
 		* Remove URL Param
+		* Remove item from array-type wp-query property.
+		* This function receives a key-value pair from element-attributes, removes the value on a destination url-string if present and removes key if is last value.
 		**/
 		removeUrlParam : function( e ) {
 

--- a/public/js/wp-ajax-public.js
+++ b/public/js/wp-ajax-public.js
@@ -45,7 +45,7 @@
 							taxo : "none",
 							terms : "all",
 							args : {
-								posts_per_page : 2,
+								// posts_per_page : 2,
 							},
 							query : "",
 							data : {},

--- a/public/js/wp-ajax-public.js
+++ b/public/js/wp-ajax-public.js
@@ -98,7 +98,7 @@
 		* @param {number} i The index of the loop instance
 		**/
 		init_ajax : function( i ) {
-			console.log( 'wpAjax.vars.loops[i].vars', wpAjax.vars.loops[i].vars );
+
 			return $.ajax({
 				url : wp_ajax_params.ajaxurl, // AJAX handler
 				data : wpAjax.vars.loops[i].vars.data,


### PR DESCRIPTION
## Description
> `post_type` was available as a filter via get-param, output-element attribute config, & end-user ui-controls. This adds `posts_per_page` & introduces new design considerations around wp-query argument manipulation when array is not an acceptable argument

This PR duplicates the all of the actions associated with modifying a single top-level argument in wp-query, with the exception that it adds a variable-swap ux-functionality which was previously only ever pop/push... Planning to further revise ux in/around query-variable swapping when multiple variable option present in user-interface

`[wp-ajax][/wp-ajax]` shortcodes will now output the posts_per_page as cofigured in wp-admin >> Settings >> Reading

posts_per_page wp-query argument can be modified as follows:
- via `ajax_posts_per_page` get-param
- via shortcode or output element config: `[wp-ajax posts_per_page="2"][/wp-ajax]` or `<div class="wp-ajax-wrap" posts_per_page="2">`
- via nested-shortcode filter `[wp-ajax posts_per_page="2"][ajax_filter query_var="posts_per_page" query_val="5,3,1"][/wp-ajax]` (query_val=Array currently needs work, single values work fine)
- and, of course, we can work just with markup, rather than shortcodes if we like ... 
```
<div class="wp-ajax-wrap" posts_per_page="2">
    <div class="wp-ajax-filter">
        <button class="wp-ajax-filter--option wp-ajax-filter--option-inactive" 
            data-query_var="ajax_posts_per_page" 
            data-query_val="5">5</button>
    </div>
    <article class="wp-ajax-feed"></article>
    <button class="wp-ajax-load">load more</button>
</div>
```

